### PR TITLE
Added Chat Dialog Option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.22'
+def runeLiteVersion = '1.6.36.2'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/NPCOverheadDialogue/NPCOverheadDialogueConfig.java
+++ b/src/main/java/com/NPCOverheadDialogue/NPCOverheadDialogueConfig.java
@@ -52,4 +52,13 @@ public interface NPCOverheadDialogueConfig extends Config
 	{
 		return false;
 	}
+	@ConfigItem(
+			keyName = "chatDialog",
+			name = "Display Overhead Dialog in Chat",
+			description = "Displays all enabled dialog in the chat"
+	)
+	default boolean enableChatDialog()
+	{
+		return false;
+	}
 }

--- a/src/main/java/com/NPCOverheadDialogue/NPCOverheadDialoguePlugin.java
+++ b/src/main/java/com/NPCOverheadDialogue/NPCOverheadDialoguePlugin.java
@@ -11,6 +11,7 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Actor;
+import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.NPC;
@@ -351,6 +352,9 @@ public class NPCOverheadDialoguePlugin extends Plugin
         {
             lastNPCText = npcDialogText;
             actor.setOverheadText(npcDialogText);
+            if(config.enableChatDialog()){
+                client.addChatMessage(ChatMessageType.PUBLICCHAT,actor.getName(), npcDialogText, actor.getName());
+            }
             actorTextTick = client.getTickCount();
         }
 
@@ -361,6 +365,9 @@ public class NPCOverheadDialoguePlugin extends Plugin
             if (client.getLocalPlayer() != null)
             {
                 client.getLocalPlayer().setOverheadText(playerDialogText);
+                if(config.enableChatDialog()){
+                    client.addChatMessage(ChatMessageType.PUBLICCHAT,client.getLocalPlayer().getName(), playerDialogText, client.getLocalPlayer().getName());
+                }
                 playerTextTick = client.getTickCount();
             }
         }
@@ -413,6 +420,9 @@ public class NPCOverheadDialoguePlugin extends Plugin
         }
         state.setDialog(dialogue);
         actor.setOverheadText(dialogue);
+        if(config.enableChatDialog()){
+            client.addChatMessage(ChatMessageType.PUBLICCHAT,actor.getName(), dialogue, actor.getName());
+        }
     }
     private String getWidgetTextSafely(final WidgetInfo info)
     {


### PR DESCRIPTION


https://user-images.githubusercontent.com/31221793/104245895-b2335400-542a-11eb-862b-fd09a3821a2c.mp4

The chat dialog option adds all the overhead text that is enabled to the chat history as if they were said in public chat.